### PR TITLE
Import previously created GitHub connect provider

### DIFF
--- a/aws_iam_openid_connect_provider.tf
+++ b/aws_iam_openid_connect_provider.tf
@@ -1,0 +1,12 @@
+resource "aws_iam_openid_connect_provider" "github" {
+  provider = aws.aws-289256138624-uw1
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = [
+    "sts.amazonaws.com"
+  ]
+  thumbprint_list = [
+    # Generated with
+    # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
+    "6938fd4d98bab03faadb97b34396831e3780aea1"
+  ]
+}


### PR DESCRIPTION
I manually created a provider for GitHub following
https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
and
https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html#manage-oidc-provider-console

Now, import it into Terraform. This provider will be needed in other
AWS accounts.
