### PR TITLE
Migrate to shared module terraform-aws-gha-admin

### DIFF
--- a/aws_iam_role.ih-tf-aws-control-289256138624.tf
+++ b/aws_iam_role.ih-tf-aws-control-289256138624.tf
@@ -1,7 +1,7 @@
 # Roles for CI/CD in the aws-control-289256138624 repo
 
 module "ih-tf-aws-control-289256138624-admin" {
-  source = "./modules/tf-admin"
+  source = "infrahouse/terraform-aws-gha-admin"
   providers = {
     aws = aws.aws-289256138624-uw1
   }

--- a/aws_iam_role.ih-tf-aws-control-289256138624.tf
+++ b/aws_iam_role.ih-tf-aws-control-289256138624.tf
@@ -1,7 +1,7 @@
 # Roles for CI/CD in the aws-control-289256138624 repo
 
 module "ih-tf-aws-control-289256138624-admin" {
-  source = "infrahouse/terraform-aws-gha-admin"
+  source = "github.com/infrahouse/terraform-aws-gha-admin"
   providers = {
     aws = aws.aws-289256138624-uw1
   }


### PR DESCRIPTION
The module does the same job but it has to create similar roles in other repos.
Begin published in GitHub allows reusing it.
