### PR TITLE
Allow state manager role store .zip archives in the state bucket

### DIFF
--- a/modules/state-manager-role/main.tf
+++ b/modules/state-manager-role/main.tf
@@ -29,7 +29,8 @@ data "aws_iam_policy_document" "permissions" {
     ]
     resources = [
       "arn:aws:s3:::${var.state_bucket}/${var.state_key}",
-      "arn:aws:s3:::${var.state_bucket}/plans/*"
+      "arn:aws:s3:::${var.state_bucket}/plans/*",
+      "arn:aws:s3:::${var.state_bucket}/*.zip"
     ]
   }
   statement {


### PR DESCRIPTION
This is needed to store lambda code archives
