### PR TITLE
Add variable read_only_permissions to state-manager-role

### DIFF
--- a/modules/state-bucket/terraform.tf
+++ b/modules/state-bucket/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.67"
+      version = "~> 5.11"
     }
   }
 }

--- a/modules/state-manager-role/terraform.tf
+++ b/modules/state-manager-role/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.67"
+      version = "~> 5.11"
     }
   }
 }

--- a/modules/state-manager-role/variables.tf
+++ b/modules/state-manager-role/variables.tf
@@ -6,6 +6,11 @@ variable "gha_role_arn" {
 variable "name" {
   description = "Role name"
 }
+variable "read_only_permissions" {
+  description = "Whether the role should have read-only permissions on the state bucket. It's needed for roles that access the state via terraform_remote_state data source."
+  type        = bool
+  default     = false
+}
 
 variable "state_bucket" {
   description = "Name of the S3 bucket with the state"

--- a/modules/tf-admin/terraform.tf
+++ b/modules/tf-admin/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.67"
+      version = "~> 5.11"
     }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,4 @@
 terraform {
-  #  backend "local" {}
   backend "s3" {
     bucket         = "infrahouse-aws-control-289256138624"
     key            = "terraform.tfstate"
@@ -12,7 +11,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.67"
+      version = "~> 5.11"
     }
   }
 }


### PR DESCRIPTION
This is to support roles that can read from the state but cannot write to
it (duh) - which is for terraform_remote_state Data Source.

To make it possible the role permissions are split in rw and ro.
The rw policy is attached to the role only if read_only_permissions is
false.
