### PR TITLE
Rename variable gha_role_arn to assuming_role_arn.

### DIFF
--- a/aws_iam_role.ih-tf-aws-control-289256138624.tf
+++ b/aws_iam_role.ih-tf-aws-control-289256138624.tf
@@ -16,7 +16,7 @@ module "ih-tf-aws-control-289256138624-state-manager" {
     aws = aws.aws-289256138624-uw1
   }
   name                      = "ih-tf-aws-control-${local.aws_account_id.terraform-control}-state-manager"
-  gha_role_arn              = module.ih-tf-aws-control-289256138624-admin.gha_role_arn
+  assuming_role_arn         = module.ih-tf-aws-control-289256138624-admin.gha_role_arn
   state_bucket              = "infrahouse-aws-control-${local.aws_account_id.terraform-control}"
   terraform_locks_table_arn = aws_dynamodb_table.terraform_locks.arn
 }

--- a/aws_iam_role.ih-tf-aws-control-303467602807.tf
+++ b/aws_iam_role.ih-tf-aws-control-303467602807.tf
@@ -6,7 +6,7 @@ module "ih-tf-aws-control-303467602807-state-manager" {
     aws = aws.aws-289256138624-uw1
   }
   name                      = "ih-tf-aws-control-${local.aws_account_id.ci-cd}-state-manager"
-  gha_role_arn              = "arn:aws:iam::${local.aws_account_id.ci-cd}:role/ih-tf-aws-control-${local.aws_account_id.ci-cd}-github"
+  assuming_role_arn         = "arn:aws:iam::${local.aws_account_id.ci-cd}:role/ih-tf-aws-control-${local.aws_account_id.ci-cd}-github"
   state_bucket              = "infrahouse-aws-control-${local.aws_account_id.ci-cd}"
   terraform_locks_table_arn = aws_dynamodb_table.terraform_locks.arn
 }

--- a/aws_iam_role.ih-tf-aws-control-493370826424.tf
+++ b/aws_iam_role.ih-tf-aws-control-493370826424.tf
@@ -6,7 +6,7 @@ module "ih-tf-aws-control-493370826424-state-manager" {
     aws = aws.aws-289256138624-uw1
   }
   name                      = "ih-tf-aws-control-${local.aws_account_id.management}-state-manager"
-  gha_role_arn              = "arn:aws:iam::${local.aws_account_id.management}:role/ih-tf-aws-control-${local.aws_account_id.management}-github"
+  assuming_role_arn         = "arn:aws:iam::${local.aws_account_id.management}:role/ih-tf-aws-control-${local.aws_account_id.management}-github"
   state_bucket              = "infrahouse-aws-control-${local.aws_account_id.management}"
   terraform_locks_table_arn = aws_dynamodb_table.terraform_locks.arn
 }

--- a/aws_iam_role.ih-tf-aws-control-990466748045.tf
+++ b/aws_iam_role.ih-tf-aws-control-990466748045.tf
@@ -6,7 +6,7 @@ module "ih-tf-aws-control-990466748045-state-manager" {
     aws = aws.aws-289256138624-uw1
   }
   name                      = "ih-tf-aws-control-state-manager"
-  gha_role_arn              = "arn:aws:iam::${local.aws_account_id.control}:role/ih-tf-aws-control-github"
+  assuming_role_arn         = "arn:aws:iam::${local.aws_account_id.control}:role/ih-tf-aws-control-github"
   state_bucket              = "infrahouse-aws-control-${local.aws_account_id.control}"
   terraform_locks_table_arn = aws_dynamodb_table.terraform_locks.arn
 }

--- a/modules/state-manager-role/main.tf
+++ b/modules/state-manager-role/main.tf
@@ -8,7 +8,7 @@ data "aws_iam_policy_document" "assume" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::990466748045:user/aleks",
-        var.gha_role_arn
+        var.assuming_role_arn
       ]
     }
   }

--- a/modules/state-manager-role/variables.tf
+++ b/modules/state-manager-role/variables.tf
@@ -1,5 +1,5 @@
-variable "gha_role_arn" {
-  description = "Role that assumes a GitHub Actions worker"
+variable "assuming_role_arn" {
+  description = "Role that is allowed to assume this role. For example, a GitHub Actions worker has a role. The GHA role needs to be able to assume the state-manager role."
   type        = string
 }
 


### PR DESCRIPTION
It just makes more sense - not only GitHub Actions can assume the role.
Other usecase is a role for terraform_remote_state. In future the
toolkit/library may need to read from the state.
