### PR TITLE
Allow ih-tf-github-control-github to assume ih-tf-terraform-control

### DIFF
--- a/aws_iam_role.ih-tf-terraform-control.tf
+++ b/aws_iam_role.ih-tf-terraform-control.tf
@@ -8,7 +8,8 @@ data "aws_iam_policy_document" "ih-tf-terraform-control-assume" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::990466748045:user/aleks",
-        "arn:aws:iam::303467602807:role/ih-tf-github-control-github"
+        "arn:aws:iam::303467602807:role/ih-tf-github-control-github",
+        "arn:aws:iam::303467602807:assumed-role/ih-tf-github-control-github/*"
       ]
     }
   }


### PR DESCRIPTION
If ih-tf-github-control-github was assumed, still allow it to assume
ih-tf-terraform-control.

Apparently, IAM distinquishes the two.
