### PR TITLE
Remove bucket infrahouse-github-state

### DIFF
--- a/aws_s3_bucket.tf
+++ b/aws_s3_bucket.tf
@@ -24,10 +24,6 @@ locals {
       description : "Terraform state for https://github.com/infrahouse/infrahouse-website-infra",
       "repo" : "infrahouse/infrahouse-website-infra"
     }
-    "infrahouse-github-state" : {
-      description : "Terraform state for https://github.com/infrahouse8/github-control",
-      "repo" : "infrahouse8/github-control"
-    }
 
   }
 }


### PR DESCRIPTION
The state has migrated to s3://infrahouse-github-control-state
