### PR TITLE
Add root account SSO admin as trusted role.

### DIFF
--- a/aws_iam_role.ih-tf-aws-control-289256138624.tf
+++ b/aws_iam_role.ih-tf-aws-control-289256138624.tf
@@ -11,7 +11,9 @@ module "ih-tf-aws-control-289256138624-admin" {
   state_bucket             = "infrahouse-aws-control-${local.aws_account_id.terraform-control}"
   gh_org_name              = "infrahouse"
   admin_allowed_arns = [
-    local.me_arn
+    local.me_arn,
+    local.aws_control_admin_arn,
+    "arn:aws:iam::493370826424:role/ih-tf-aws-control-493370826424-github"
   ]
 }
 
@@ -24,6 +26,7 @@ module "ih-tf-aws-control-289256138624-state-manager" {
   name = "ih-tf-aws-control-${local.aws_account_id.terraform-control}-state-manager"
   assuming_role_arns = [
     module.ih-tf-aws-control-289256138624-admin.github_role_arn,
+    local.aws_control_admin_arn,
     local.me_arn
   ]
   state_bucket              = "infrahouse-aws-control-${local.aws_account_id.terraform-control}"

--- a/locals.tf
+++ b/locals.tf
@@ -6,5 +6,6 @@ locals {
     ci-cd : "303467602807"
     management : "493370826424"
   }
-  me_arn = "arn:aws:iam::990466748045:user/aleks"
+  me_arn                = "arn:aws:iam::990466748045:user/aleks"
+  aws_control_admin_arn = "arn:aws:iam::990466748045:role/aws-reserved/sso.amazonaws.com/us-west-1/AWSReservedSSO_AWSAdministratorAccess_16bdbe5eb442e7ef"
 }


### PR DESCRIPTION
The `AWSReservedSSO_AWSAdministratorAccess_16bdbe5eb442e7ef` role, assumed via SSO should be trusted to manage 289256138624 account.
